### PR TITLE
Change `fromTwitterFuture` to accept a call-by-name `Future`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ object Example extends App {
       for {
         _        <- putStrLn("Hello! What is your name?")
         name     <- getStrLn
-        greeting <- Task.fromTwitterFuture(Task(greet(name)))
+        greeting <- Task.fromTwitterFuture(greet(name))
         _        <- putStrLn(greeting)
       } yield ()
 

--- a/src/main/scala/zio/interop/twitter.scala
+++ b/src/main/scala/zio/interop/twitter.scala
@@ -22,7 +22,14 @@ import zio.{ Runtime, Task, UIO, ZIO }
 
 package object twitter {
   implicit class TaskObjOps(private val obj: Task.type) extends AnyVal {
+    final def fromTwitterFuture[A](future: => Future[A]): Task[A] =
+      toTask(Task(future))
+
+    @deprecated("Use fromTwitterFuture[A](future: => Future[A]) instead", "v20.6.0.0-RC2")
     final def fromTwitterFuture[A](future: Task[Future[A]]): Task[A] =
+      toTask(future)
+
+    private def toTask[A](future: Task[Future[A]]): Task[A] =
       Task.uninterruptibleMask { restore =>
         future.flatMap { f =>
           restore(Task.effectAsync { cb: (Task[A] => Unit) =>

--- a/src/test/scala/zio/interop/TwitterSpec.scala
+++ b/src/test/scala/zio/interop/TwitterSpec.scala
@@ -18,14 +18,14 @@ object TwitterSpec extends DefaultRunnableSpec {
       suite("Task.fromTwitterFuture")(
         testM("return failing `Task` if future failed.") {
           val error  = new Exception
-          val future = Task(Future.exception[Int](error))
+          def future = Future.exception[Int](error)
           val task   = Task.fromTwitterFuture(future).unit
 
           assertM(task.either)(isLeft(equalTo(error)))
         },
         testM("return successful `Task` if future succeeded.") {
           val value  = 10
-          val future = Task(Future.value(value))
+          def future = Future.value(value)
           val task   = Task.fromTwitterFuture(future).option
 
           assertM(task)(isSome(equalTo(value)))
@@ -37,7 +37,7 @@ object TwitterSpec extends DefaultRunnableSpec {
             override protected def onInterrupt(t: Throwable): Unit = setException(t)
           }
 
-          val future = Task(promise.flatMap(_ => Future(value.incrementAndGet())))
+          def future = promise.flatMap(_ => Future(value.incrementAndGet()))
 
           val task =
             (for {


### PR DESCRIPTION
This PR simplifies the usage of `fromTwitterFuture` to avoid having to wrap every `Future` into a `Task`. 

Currently the usage of `fromTwitterFuture` expects its input `com.twitter.util.Future` to be wrapped in a `Task`, amongst other things, in order to defer the execution of the `Future` until the effect is executed. However it can be simplified by using a call-by-name argument and then wrapping it in a `Task` within the implementation.

It should be noted that regardless of the current or proposed new usage the user should be responsible of defining their Futures as `lazy val` or `def` in order to avoid eager execution.

Fixes #117 