### PR TITLE
Fix tests

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,15 +1,15 @@
-version = "2.6.4"
+version = "3.2.1"
 maxColumn = 120
 align.preset = most
 continuationIndent.defnSite = 2
 assumeStandardLibraryStripMargin = true
-docstrings = JavaDoc
+docstrings.style = Asterisk
 lineEndings = preserve
 includeCurlyBraceInSelectChains = false
-danglingParentheses = true
+danglingParentheses.preset = true
 spaces {
   inImportCurlyBraces = true
 }
 optIn.annotationNewlines = true
-
+runner.dialect = scala213
 rewrite.rules = [SortImports, RedundantBraces]

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,9 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 inThisBuild(
   List(
     organization := "dev.zio",
-    homepage := Some(url("https://zio.dev")),
-    licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
-    developers := List(
+    homepage     := Some(url("https://zio.dev")),
+    licenses     := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+    developers   := List(
       Developer(
         "jdegoes",
         "John De Goes",

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -25,7 +25,7 @@ object BuildHelper {
   val Scala212: String = versions("2.12")
   val Scala213: String = versions("2.13")
 
-  val Zio: String = "1.0.12"
+  val Zio: String = "1.0.13"
 
   def buildInfoSettings(packageName: String) =
     List(

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -29,17 +29,17 @@ object BuildHelper {
 
   def buildInfoSettings(packageName: String) =
     List(
-      buildInfoKeys := List[BuildInfoKey](name, version, scalaVersion, sbtVersion, isSnapshot),
+      buildInfoKeys    := List[BuildInfoKey](name, version, scalaVersion, sbtVersion, isSnapshot),
       buildInfoPackage := packageName,
-      buildInfoObject := "BuildInfo"
+      buildInfoObject  := "BuildInfo"
     )
 
   def stdSettings(prjName: String) =
     Seq(
-      name := s"$prjName",
-      crossScalaVersions := List(Scala211, Scala212, Scala213),
+      name                     := s"$prjName",
+      crossScalaVersions       := List(Scala211, Scala212, Scala213),
       ThisBuild / scalaVersion := Scala213,
-      scalacOptions := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
+      scalacOptions            := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
       Test / parallelExecution := true,
       incOptions ~= (_.withLogRecompileOnMacro(false))
     )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("ch.epfl.scala"  % "sbt-bloop"      % "1.4.11")
 addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"  % "0.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.4.4")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.4.5")
 
 libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.3"

--- a/sbt
+++ b/sbt
@@ -34,11 +34,11 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.3.13"
-declare -r sbt_unreleased_version="1.4.0-M1"
+declare -r sbt_release_version="1.5.5"
+declare -r sbt_unreleased_version="1.6.0-M1"
 
-declare -r latest_213="2.13.3"
-declare -r latest_212="2.12.12"
+declare -r latest_213="2.13.7"
+declare -r latest_212="2.12.15"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"
@@ -48,7 +48,7 @@ declare -r buildProps="project/build.properties"
 
 declare -r sbt_launch_ivy_release_repo="https://repo.typesafe.com/typesafe/ivy-releases"
 declare -r sbt_launch_ivy_snapshot_repo="https://repo.scala-sbt.org/scalasbt/ivy-snapshots"
-declare -r sbt_launch_mvn_release_repo="https://repo.scala-sbt.org/scalasbt/maven-releases"
+declare -r sbt_launch_mvn_release_repo="https://repo1.maven.org/maven2"
 declare -r sbt_launch_mvn_snapshot_repo="https://repo.scala-sbt.org/scalasbt/maven-snapshots"
 
 declare -r default_jvm_opts_common="-Xms512m -Xss2m -XX:MaxInlineLevel=18"
@@ -216,7 +216,8 @@ getJavaVersion() {
   # but on 9 and 10 it's 9.x.y and 10.x.y.
   if [[ "$str" =~ ^1\.([0-9]+)(\..*)?$ ]]; then
     echo "${BASH_REMATCH[1]}"
-  elif [[ "$str" =~ ^([0-9]+)(\..*)?$ ]]; then
+  # Fixes https://github.com/dwijnand/sbt-extras/issues/326
+  elif [[ "$str" =~ ^([0-9]+)(\..*)?(-ea)?$ ]]; then
     echo "${BASH_REMATCH[1]}"
   elif [[ -n "$str" ]]; then
     echoerr "Can't parse java version from: $str"
@@ -247,11 +248,20 @@ java_version() {
   echo "$version"
 }
 
+is_apple_silicon() { [[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]]; }
+
 # MaxPermSize critical on pre-8 JVMs but incurs noisy warning on 8+
 default_jvm_opts() {
   local -r v="$(java_version)"
-  if [[ $v -ge 10 ]]; then
-    echo "$default_jvm_opts_common -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+  if [[ $v -ge 17 ]]; then
+    echo "$default_jvm_opts_common"
+  elif [[ $v -ge 10 ]]; then
+    if is_apple_silicon; then
+      # As of Dec 2020, JVM for Apple Silicon (M1) doesn't support JVMCI
+      echo "$default_jvm_opts_common"
+    else
+      echo "$default_jvm_opts_common -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+    fi
   elif [[ $v -ge 8 ]]; then
     echo "$default_jvm_opts_common"
   else
@@ -471,7 +481,7 @@ process_args() {
       -trace)       require_arg integer "$1" "$2" && trace_level="$2" && shift 2 ;;
       -debug-inc)   addJava "-Dxsbt.inc.debug=true" && shift ;;
 
-      -no-colors)   addJava "-Dsbt.log.noformat=true" && shift ;;
+      -no-colors)   addJava "-Dsbt.log.noformat=true" && addJava "-Dsbt.color=false" && shift ;;
       -sbt-create)  sbt_create=true && shift ;;
       -sbt-dir)     require_arg path "$1" "$2" && sbt_dir="$2" && shift 2 ;;
       -sbt-boot)    require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;

--- a/sbt
+++ b/sbt
@@ -34,7 +34,7 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.5.5"
+declare -r sbt_release_version="1.5.8"
 declare -r sbt_unreleased_version="1.6.0-M1"
 
 declare -r latest_213="2.13.7"

--- a/src/main/scala/zio/interop/twitter.scala
+++ b/src/main/scala/zio/interop/twitter.scala
@@ -21,7 +21,7 @@ import zio.{ RIO, Runtime, Task, UIO }
 
 package object twitter {
   implicit class TaskObjOps(private val obj: Task.type) extends AnyVal {
-    final def fromTwitterFuture[A](future: => Future[A]): Task[A] = {
+    final def fromTwitterFuture[A](future: => Future[A]): Task[A] =
       Task.effectSuspend {
         println("effectSuspend")
         Task(future).flatMap { future =>
@@ -33,7 +33,6 @@ package object twitter {
           }.onInterrupt(UIO(future.raise(new FutureCancelledException)))
         }
       }
-    }
   }
 
   implicit class RuntimeOps[R](private val runtime: Runtime[R]) extends AnyVal {

--- a/src/main/scala/zio/interop/twitter.scala
+++ b/src/main/scala/zio/interop/twitter.scala
@@ -29,7 +29,15 @@ package object twitter {
               case Return(a) => cb(Task.succeedNow(a))
               case Throw(e)  => cb(Task.fail(e))
             }
-          }).onInterrupt(UIO(future.raise(new FutureCancelledException)))
+          }).onInterrupt {
+            UIO(future.raise(new FutureCancelledException)) *>
+              UIO.effectAsync { (cb: UIO[Unit] => Unit) =>
+                future.respond {
+                  case Return(a) => cb(Task.succeedNow(()))
+                  case Throw(e)  => cb(Task.succeedNow(()))
+                }
+              }
+          }
         }
       }
   }

--- a/src/main/scala/zio/interop/twitter.scala
+++ b/src/main/scala/zio/interop/twitter.scala
@@ -48,7 +48,7 @@ package object twitter {
       val interruptible =
         for {
           f <- rio.fork
-          _ <- Task.effect(promise.setInterruptHandler { case _ => runtime.unsafeRunAsync_(f.interrupt) })
+          _ <- Task(promise.setInterruptHandler { case _ => runtime.unsafeRunAsync_(f.interrupt) })
           r <- f.join
         } yield r
 

--- a/src/main/scala/zio/interop/twitter.scala
+++ b/src/main/scala/zio/interop/twitter.scala
@@ -33,8 +33,8 @@ package object twitter {
             UIO(future.raise(new FutureCancelledException)) *>
               UIO.effectAsync { (cb: UIO[Unit] => Unit) =>
                 future.respond {
-                  case Return(a) => cb(Task.succeedNow(()))
-                  case Throw(e)  => cb(Task.succeedNow(()))
+                  case Return(_) => cb(Task.unit)
+                  case Throw(_)  => cb(Task.unit)
                 }
               }
           }

--- a/src/main/scala/zio/interop/twitter.scala
+++ b/src/main/scala/zio/interop/twitter.scala
@@ -32,7 +32,7 @@ package object twitter {
       Task.uninterruptibleMask { restore =>
         future.flatMap { f =>
           restore(Task.effectAsync { cb: (Task[A] => Unit) =>
-            val _ = f.respond {
+            f.respond {
               case Return(a) => cb(Task.succeed(a))
               case Throw(e)  => cb(Task.fail(e))
             }

--- a/src/main/scala/zio/interop/twitter.scala
+++ b/src/main/scala/zio/interop/twitter.scala
@@ -22,15 +22,8 @@ import zio.{ RIO, Runtime, Task, UIO }
 package object twitter {
   implicit class TaskObjOps(private val obj: Task.type) extends AnyVal {
     final def fromTwitterFuture[A](future: => Future[A]): Task[A] =
-      toTask(Task(future))
-
-    @deprecated("Use fromTwitterFuture[A](future: => Future[A]) instead", "v20.6.0.0-RC2")
-    final def fromTwitterFuture[A](future: Task[Future[A]]): Task[A] =
-      toTask(future)
-
-    private def toTask[A](future: Task[Future[A]]): Task[A] =
       Task.uninterruptibleMask { restore =>
-        future.flatMap { f =>
+        Task(future).flatMap { f =>
           restore(Task.effectAsync { cb: (Task[A] => Unit) =>
             f.respond {
               case Return(a) => cb(Task.succeed(a))

--- a/src/test/scala/zio/interop/TwitterSpec.scala
+++ b/src/test/scala/zio/interop/TwitterSpec.scala
@@ -56,15 +56,10 @@ object TwitterSpec extends DefaultRunnableSpec {
         },
         testM("ensures task is interrupted") {
           for {
-            promise <- Promise.make[Throwable, Unit]
-            ref     <- Ref.make(false)
-            task     = promise.await *> ref.set(true)
-            future  <- Task.effect(runtime.unsafeRunToTwitterFuture(task))
-            _       <- Task.effect(future.raise(new Exception))
-            _       <- promise.succeed(())
-            value   <- ref.get
-            status  <- Task.effect(Await.result(future)).either
-          } yield assert(value)(isFalse) && assert(status)(isLeft)
+            future <- Task(runtime.unsafeRunToTwitterFuture(UIO.never))
+            _      <- Task(future.raise(new Exception))
+            status <- Task(Await.result(future)).either
+          } yield assert(status)(isLeft)
         } @@ nonFlaky
       )
     )

--- a/src/test/scala/zio/interop/TwitterSpec.scala
+++ b/src/test/scala/zio/interop/TwitterSpec.scala
@@ -1,6 +1,6 @@
 package zio.interop
 
-import com.twitter.util.{ Await, Future }
+import com.twitter.util.{ Await, Future, FuturePool }
 import java.util.concurrent.atomic.AtomicInteger
 import zio._
 import zio.duration._
@@ -9,7 +9,6 @@ import zio.test._
 import zio.test.Assertion._
 import zio.test.TestAspect.nonFlaky
 import zio.test.environment.Live
-import com.twitter.util.FuturePool
 
 object TwitterSpec extends DefaultRunnableSpec {
   val runtime = runner.runtime

--- a/src/test/scala/zio/interop/TwitterSpec.scala
+++ b/src/test/scala/zio/interop/TwitterSpec.scala
@@ -36,6 +36,7 @@ object TwitterSpec extends DefaultRunnableSpec {
             ref   <- UIO(new AtomicInteger(0))
             fiber <- Task.fromTwitterFuture(infiniteFuture(ref)).fork
             _     <- fiber.interrupt
+            _     <- Live.live(clock.sleep(20.millis))
             v1    <- UIO(ref.get)
             _     <- Live.live(clock.sleep(10.millis))
             v2    <- UIO(ref.get)

--- a/src/test/scala/zio/interop/TwitterSpec.scala
+++ b/src/test/scala/zio/interop/TwitterSpec.scala
@@ -37,7 +37,6 @@ object TwitterSpec extends DefaultRunnableSpec {
             ref   <- UIO(new AtomicInteger(0))
             fiber <- Task.fromTwitterFuture(infiniteFuture(ref)).fork
             _     <- fiber.interrupt
-            _     <- Live.live(clock.sleep(10.millis))
             v1    <- UIO(ref.get)
             _     <- Live.live(clock.sleep(10.millis))
             v2    <- UIO(ref.get)

--- a/src/test/scala/zio/interop/TwitterSpec.scala
+++ b/src/test/scala/zio/interop/TwitterSpec.scala
@@ -37,6 +37,7 @@ object TwitterSpec extends DefaultRunnableSpec {
             ref   <- UIO(new AtomicInteger(0))
             fiber <- Task.fromTwitterFuture(infiniteFuture(ref)).fork
             _     <- fiber.interrupt
+            _     <- Live.live(clock.sleep(10.millis))
             v1    <- UIO(ref.get)
             _     <- Live.live(clock.sleep(10.millis))
             v2    <- UIO(ref.get)

--- a/src/test/scala/zio/interop/TwitterSpec.scala
+++ b/src/test/scala/zio/interop/TwitterSpec.scala
@@ -9,7 +9,7 @@ import zio.test._
 import zio.test.Assertion._
 import zio.test.TestAspect.flaky
 
-import scala.util.{ Failure, Success, Try }
+import scala.util.Try
 
 object TwitterSpec extends DefaultRunnableSpec {
   val runtime = runner.runtime
@@ -54,16 +54,11 @@ object TwitterSpec extends DefaultRunnableSpec {
           assert(Await.result(runtime.unsafeRunToTwitterFuture(Task.succeed(2))))(equalTo(2))
         },
         test("return failed `Future` if Task evaluation failed.") {
-          val error = new Exception
-          val task  = Task.fail(error).unit
+          val error  = new Exception
+          val task   = Task.fail(error).unit
+          val result = Try(Await.result(runtime.unsafeRunToTwitterFuture(task)))
 
-          val result =
-            Try(Await.result(runtime.unsafeRunToTwitterFuture(task))) match {
-              case Failure(exception) => Some(exception)
-              case Success(_)         => None
-            }
-
-          assert(result)(isSome(equalTo(error)))
+          assert(result)(isFailure(equalTo(error)))
         },
         testM("ensure Task evaluation is interrupted together with Future.") {
           for {

--- a/src/test/scala/zio/interop/TwitterSpec.scala
+++ b/src/test/scala/zio/interop/TwitterSpec.scala
@@ -9,6 +9,7 @@ import zio.test._
 import zio.test.Assertion._
 import zio.test.TestAspect.nonFlaky
 import zio.test.environment.Live
+import com.twitter.util.FuturePool
 
 object TwitterSpec extends DefaultRunnableSpec {
   val runtime = runner.runtime
@@ -30,7 +31,7 @@ object TwitterSpec extends DefaultRunnableSpec {
         },
         testM("ensures future is interrupted") {
           def infiniteFuture(ref: AtomicInteger): Future[Nothing] =
-            Future(ref.getAndIncrement()).flatMap(_ => infiniteFuture(ref))
+            FuturePool.interruptibleUnboundedPool(ref.getAndIncrement()).flatMap(_ => infiniteFuture(ref))
 
           for {
             ref   <- UIO(new AtomicInteger(0))

--- a/src/test/scala/zio/interop/TwitterSpec.scala
+++ b/src/test/scala/zio/interop/TwitterSpec.scala
@@ -54,7 +54,7 @@ object TwitterSpec extends DefaultRunnableSpec {
             result <- Task(unsafeAwait(Task.fail(error))).either
           } yield assert(result)(isLeft(equalTo(error)))
         },
-        testM("ensures Task evaluation is interrupted together with Future.") {
+        testM("ensures task is interrupted") {
           for {
             promise <- zio.Promise.make[Throwable, Unit]
             ref     <- zio.Ref.make(false)


### PR DESCRIPTION
closes #226, closes #228, closes #230

### Summary

- ported the future interruption test from ZIO
- removed race from task interruption test
- updated tools (sbt, sbtx, scalafmt)